### PR TITLE
Adding a tuple setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ This repository houses the documents and discussions that govern Typelevel.
 * The [Typelevel Trademark Policy](TRADEMARKS.md)
 * The present [Typelevel Steering Committee](STEERING-COMMITTEE.md)
 
+## Other Resources
+
+* We are pleased to offer Typelevel contributors access to a license for [Tuple, pair programming software](https://tuple.app/). 
+Please read [our guide for how to set it up](/resources/tuple.md).
+
 ## Contributing
 
 Typelevel is a collaborative organization of volunteers.  We welcome

--- a/resources/tuple.md
+++ b/resources/tuple.md
@@ -1,0 +1,42 @@
+# Pair Programming with Tuple
+
+[Tuple](https://tuple.app/) is a pair programming tool with clients available for MacOS and Linux (beta). 
+Tuple provides low latency screen-sharing, crisp audio and visual (video is optional), easy-to-handoff mouse and keyboard control, as well as a very helpful screen drawing feature for whiteboarding.
+
+- You can [download Tuple here](https://tuple.app/downloads/)
+- You can [read more about pairing here](https://tuple.app/pair-programming-guide)
+
+We expect any usage of Tuple to abide by our [code of conduct](https://typelevel.org/code-of-conduct). Please follow the contact procedures outlined in the code of conduct for any questions or to report a violation. 
+
+## For Typelevel Maintainers
+
+#### Getting Setup
+
+Members of the Typelevel GitHub organization have access to a Tuple license as part of the Typelevel Tuple team. 
+You can request to be added to the team via any of the following:
+- [opening a GitHub issue in this repo](https://github.com/typelevel/governance/issues/new?labels=tuple&body=cc+@samspills)
+  - please provide the email address you intend to use with Tuple
+  - The link should autopopulate but in case it doesn't: please use the `tuple` label, and tag `@samspills` in the body of the issue
+- asking an existing member of the Typelevel Tuple team to [invite you to the team](https://docs.tuple.app/article/41-inviting-users)
+- posting a message in the `#admin` channel in the Typelevel Discord
+  - feel free to tag `@spills` in your message
+  - please include the email you intend to use with Tuple
+
+Only one person in a pairing session needs access to a license. This means that Typelevel members can pair with new contributors without inviting them to the Typelevel team. 
+Tuple does not integrate with GitHub and we only have a limited number of seats available, so please try to ensure only maintainers are added to the team.
+
+#### Pairing with New Contributors
+
+You can pair with new contributors by following these steps:
+1. point them to the [New Contributors section](#for-new-contributors-and-guests) so they can get setup
+2. add them as a `friend outside my team`, following [the alternate invite instructions](https://docs.tuple.app/article/41-inviting-users)
+3. you can now start a pairing session with them the same way you would with someone within the team
+
+## For New Contributors and Guests
+
+New contributors and guests are able to pair with any member of the Typelevel organization without a Tuple license of their own. 
+To get setup, follow these steps:
+
+1. [download Tuple here](https://tuple.app/downloads/)
+2. Share the email address used to setup Tuple with the person you'd like to pair with
+3. They can then initiate a pairing session with you.


### PR DESCRIPTION
This PR 
- adds an `other resources` section in the main readme that calls out tuple
- adds a resources directory, and a `tuple.md` in that directory
  - putting it in the main directory felt a bit messy, it's definitely a different class of document than the charter 
- tuple.md with instructions for getting set up
  - how to join the team for maintainers
  - quick instructions for new contributors/guests

It's "ready for review" in that I'd love to get other peoples thoughts on clarity, but also this is just my first draft. I've tried to fix my tenses but I'll definitely be giving it a second pass tomorrow.