### PR TITLE
Add 'Why Join Typelevel' section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,31 @@ This repository houses the documents and discussions that govern Typelevel.
 * The [Typelevel Trademark Policy](TRADEMARKS.md)
 * The present [Typelevel Steering Committee](STEERING-COMMITTEE.md)
 
+
+## Why Join Typelevel?
+
+The Typelevel ecosystem covers a wide range of domains including functional programming, high performance microservices, generic programming, tooling, and more. Projects that work well with or align with the goals of existing projects are invited to consider joining Typelevel.
+
+There are two ways a project can join Typelevel, as an [organization project](https://typelevel.org/projects/organization/) and as an [affiliate project](https://typelevel.org/projects/affiliate/). Both of these membership types are [officially described in the charter](https://github.com/typelevel/governance/blob/main/CHARTER.md#8-project-criteria).
+
+The main difference is that organization projects are hosted by Typelevel (at [github.com/typelevel](https://github.com/typelevel)) and agree to follow the guidance and direction of the steering committee.
+
+
+**Organization Projects:**
+- listed on Typelevel homepage
+- hosted by Typelevel
+- are published under the org.typelevel group id
+- receive build and maintenance help from the Typelevel team
+- get updated by [typelevel steward](https://github.com/typelevel/steward)
+- tend to use [sbt-typelevel](https://typelevel.org/sbt-typelevel/)
+
+**Affiliate Projects:**
+- listed on Typelevel homepage
+- demonstrate alignment with other Typelevel projects
+- use original release coordinates
+- can be withdrawn at any time by the author(s)
+
+
 ## Other Resources
 
 * We are pleased to offer Typelevel contributors access to a license for [Tuple, pair programming software](https://tuple.app/). 


### PR DESCRIPTION
Adds a section detailing some of the practical implications of joining Typelevel.

cc. @armanbilge