### PR TITLE
Ask for CoC and license

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-project-submission.md
+++ b/.github/ISSUE_TEMPLATE/1-project-submission.md
@@ -19,5 +19,15 @@ In accordance with the [Typelevel Charter](https://github.com/typelevel/governan
 - [ ] Organization Project
 - [ ] Affiliate Project
 
+### Project Management
+
+Typelevel projects are required to have an appropriate Code of Conduct. The [Scala Code of Conduct](https://typelevel.org/code-of-conduct) is a good option, but not specifically required. Before submitting a project for inclusion, please ensure that a pointer to its Code of Conduct is clearly linked from its README and/or website.
+
+- [ ] This project's Code of Conduct can be found at <!-- link to CoC -->
+
+Similarly, Typelevel projects must have an appropriate license, as specified in [the Typelevel Charter](https://github.com/typelevel/governance/blob/main/CHARTER.md#8-project-criteria). Please make sure that the project's license is on the approved list.
+
+- [ ] This project's license can be found at <!-- link to license -->
+
 ### Additional Notes
 <!-- Please provide some additional context about this project. -->

--- a/.github/ISSUE_TEMPLATE/1-project-submission.md
+++ b/.github/ISSUE_TEMPLATE/1-project-submission.md
@@ -21,7 +21,7 @@ In accordance with the [Typelevel Charter](https://github.com/typelevel/governan
 
 ### Project Management
 
-Typelevel projects are required to have an appropriate Code of Conduct. The [Scala Code of Conduct](https://typelevel.org/code-of-conduct) is a good option, but not specifically required. Before submitting a project for inclusion, please ensure that a pointer to its Code of Conduct is clearly linked from its README and/or website.
+Typelevel projects are required to have an appropriate Code of Conduct. The [Scala Code of Conduct](https://typelevel.org/code-of-conduct) is a good option, but not specifically required. Before submitting a project for inclusion, please ensure that a pointer to its Code of Conduct is clearly linked from its README, CODE_OF_CONDUCT.md, or website.
 
 - [ ] This project's Code of Conduct can be found at <!-- link to CoC -->
 


### PR DESCRIPTION
We're finding that lack of a CoC is the most common stumbling block slowing down applications.  So let's ask for that more explicitly.  While we're at it, remind the applicants that an appropriate license is also required.