### PR TITLE
new code of conduct, enforcement policy

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -57,8 +57,7 @@ Community members asked to stop any inappropriate behavior are expected to compl
 
 If a participant engages in behavior that violates our standards, the Typelevel Code of Conduct Committee will take any action they deem appropriate, including but not limited to: warning the offender, or expelling them from the community or current community events with no refund of event tickets.
 
-<!-- TODO link enforcement procedures -->
-The full list of consequences for inappropriate behavior is listed in the Enforcement Procedures.
+The full list of consequences for inappropriate behavior is listed in the [Enforcement Procedures](ENFORCEMENT-POLICY.md).
 
 
 

--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -25,7 +25,7 @@ Behaviors that reinforce these values contribute to a positive environment, and 
 ### Our Standards
 
 Every member of our community has the right to have their identity respected.
-The Typelevel community is dedicated to providing a positive experience for everyone, regardless of age, gender identity and expression, sexual orientation, disability, physical appearance, body size, ethnicity, nationality, race, or religion (or lack thereof), education, or socio-economic status.
+The Typelevel community is dedicated to providing a positive experience for everyone, regardless of age, gender identity and expression, sexual orientation, disability, neurodiversity, physical appearance, body size, ethnicity, nationality, race, or religion (or lack thereof), education, or socio-economic status.
 
 
 #### Inappropriate Behavior

--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -25,7 +25,7 @@ Behaviors that reinforce these values contribute to a positive environment, and 
 ### Our Standards
 
 Every member of our community has the right to have their identity respected.
-The Typelevel community is dedicated to providing a positive experience for everyone, regardless of age, gender identity and expression, sexual orientation, disability, neurodiversity, physical appearance, body size, ethnicity, nationality, race, or religion (or lack thereof), education, or socio-economic status.
+The Typelevel community is dedicated to providing a positive experience for everyone, regardless of age, gender identity and expression, sexual orientation, disability, neurodivergence, physical appearance, body size, ethnicity, nationality, race, or religion (or lack thereof), education, or socio-economic status.
 
 
 #### Inappropriate Behavior

--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,0 +1,95 @@
+## Code of Conduct
+
+The Typelevel community is made up of members from around the globe with a diverse set of skills, personalities, and experiences.
+It is through these differences that our community experiences great successes and continued growth.
+When you're working with members of the community, this Code of Conduct will help steer your interactions and keep Typelevel a positive, successful, and growing community.
+Whether you are new or familiar with our community, we care about making it a welcoming and safe place for you and we're here to support you.
+
+
+### Our Community
+
+Members of the Typelevel community are open, considerate, and respectful.
+Behaviors that reinforce these values contribute to a positive environment, and include:
+
+- **Being kind.** We treat our fellow community members with the empathy, respect and dignity all people deserve.
+- **Focusing on what is best for the community.** We're respectful of the processes set forth in the community, and we work within them.
+- **Showing empathy towards other community members.** We're attentive in our communications, whether in person or online, and we're tactful when approaching differing views.
+- **Acknowledging time and effort.** We're respectful of the volunteer efforts that permeate the Typelevel community. We're thoughtful when addressing the efforts of others, keeping in mind that often the labor was completed simply for the good of the community.
+- **Being respectful of differing viewpoints and experiences.** We remember that everyone was new to Scala at some point. We want to encourage newcomers to join our community and learn the Scala language and ecosystem. Always assume good intentions and a willingness to learn, just as you are willing to evolve your own opinion as you gain new insights.
+- **Being considerate.** Members of the community are considerate of their peers -- other Scala users.
+- **Being respectful.** We're respectful of others, their positions, their skills, their commitments, and their efforts.
+- **Gracefully accepting constructive criticism.** When we disagree, we are courteous in raising our issues.
+- **Using welcoming and inclusive language.** We're accepting of all who wish to take part in our activities, fostering an environment where anyone can participate and everyone can make a difference.
+
+
+### Our Standards
+
+Every member of our community has the right to have their identity respected.
+The Typelevel community is dedicated to providing a positive experience for everyone, regardless of age, gender identity and expression, sexual orientation, disability, physical appearance, body size, ethnicity, nationality, race, or religion (or lack thereof), education, or socio-economic status.
+
+
+#### Inappropriate Behavior
+
+Examples of unacceptable behavior by participants include:
+
+- Harassment of any participants in any form
+- Deliberate intimidation, stalking, or following
+- Logging or taking screenshots of online activity for harassment purposes
+- Publishing others' private information, such as a physical or electronic address, without explicit permission
+- Violent threats or language directed against another person
+- Incitement of violence or harassment towards any individual, including encouraging a person to commit suicide or to engage in self-harm
+- Creating additional online accounts in order to harass another person or circumvent a ban
+- Sexual language and imagery in online communities or in any conference venue, including talks
+- Insults, put downs, or jokes that are based upon stereotypes, that are exclusionary, or that hold others up for ridicule
+- Excessive swearing
+- Unwelcome sexual attention or advances
+- Unwelcome physical contact, including simulated physical contact (eg, textual descriptions like "hug" or "backrub") without consent or after a request to stop
+- Pattern of inappropriate social contact, such as requesting/assuming inappropriate levels of intimacy with others
+- Sustained disruption of online community discussions, in-person presentations, or other in-person events
+- Spamming, trolling, flaming, baiting or other attention-stealing behavior
+- Continued one-on-one communication after requests to cease
+- Other conduct that is inappropriate for a professional audience
+
+Community members asked to stop any inappropriate behavior are expected to comply immediately.
+
+
+#### Consequences
+
+If a participant engages in behavior that violates our standards, the Typelevel Code of Conduct Committee will take any action they deem appropriate, including but not limited to: warning the offender, or expelling them from the community or current community events with no refund of event tickets.
+
+<!-- TODO link enforcement procedures -->
+The full list of consequences for inappropriate behavior is listed in the Enforcement Procedures.
+
+
+
+### Scope
+
+The enforcement policies listed above apply to all official Typelevel channels, including but not limited to the following: mailing lists, both organization and affiliate GitHub repositories, Typelevel Discord server, and Typelevel venues and events.
+If unaffiliated projects adopt the Typelevel Code of Conduct, please contact the maintainers of those projects for enforcement.
+
+
+### Contact
+
+For questions related to our code of conduct, or to report possible violations, please immediately contact a member of the Typelevel Code of Conduct Committee:
+
+<!-- TODO single CoC email address -->
+  * [Jasna Rodulfa-Blemberg](mailto:jasna.robl@gmail.com)
+  * [Sam Pillsworth](mailto:sam@blerf.ca)
+  * [Andrew Valencik](mailto:andrew.valencik@gmail.com)
+
+
+## Attribution
+
+This code of conduct is a modified version of the [Python Software Foundation Code of Conduct](https://www.python.org/psf/conduct), licensed under the [Creative Commons Attribution-ShareAlike 3.0 Unported License](https://creativecommons.org/licenses/by-sa/3.0/).
+
+Additional language was incorporated from the following:
+
+* [Otter Tech](https://otter.technology/code-of-conduct-training/) resources, licensed under a [Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International](https://creativecommons.org/licenses/by-nc-sa/4.0/).
+* [Scala Code of Conduct](https://www.scala-lang.org/conduct/), licensed under a [Creative Commons Attribution-ShareAlike 3.0 Unported License](http://creativecommons.org/licenses/by-sa/3.0/).
+* [Affect Conf Code of Conduct](https://affectconf.com/coc/), licensed under a [Creative Commons Attribution-ShareAlike 3.0 Unported License](http://creativecommons.org/licenses/by-sa/3.0/).
+* [Citizen Code of Conduct](http://citizencodeofconduct.org/), licensed under a [Creative Commons Attribution-ShareAlike 3.0 Unported License](http://creativecommons.org/licenses/by-sa/3.0/).
+* [Contributor Covenant version 1.4](https://www.contributor-covenant.org/version/1/4/code-of-conduct), licensed[ Creative Commons Attribution 4.0 License](https://github.com/ContributorCovenant/contributor_covenant/blob/master/LICENSE.md).
+* [Django Project Code of Conduct](https://www.djangoproject.com/conduct/), licensed under a [Creative Commons Attribution 3.0 Unported License](http://creativecommons.org/licenses/by/3.0/).
+* [LGBTQ in Tech Slack Code of Conduct](https://lgbtq.technology/coc.html), licensed under a [Creative Commons Zero License](https://creativecommons.org/publicdomain/zero/1.0/).
+* [PyCon 2018 Code of Conduct](https://us.pycon.org/2018/about/code-of-conduct/), licensed under a [Creative Commons Attribution 3.0 Unported License](http://creativecommons.org/licenses/by/3.0/).
+* [Rust Code of Conduct](https://www.rust-lang.org/en-US/conduct.html)

--- a/ENFORCEMENT-POLICY.md
+++ b/ENFORCEMENT-POLICY.md
@@ -81,7 +81,7 @@ Reports which involve higher risk or higher impact may face more severe conseque
 
 The committee will propose a concrete behavior adjustment that ensures the inappropriate behavior is not repeated. The committee will also discuss what actions may need to be taken if the reported person does not agree to the proposed behavioral adjustment.
 
-What follows are examples of possible behavioral adjustments for incidents that occur in online spaces under the scope of this Code of Conduct. This behavioral adjustment list is not inclusive, and the Typelevel Code of Conduct Committee reserves the right to take any action it deems necessary.
+What follows are examples of possible behavioral adjustments for incidents that occur in online spaces under the scope of this Code of Conduct. This behavioral adjustment list is not exhaustive, and the Typelevel Code of Conduct Committee reserves the right to take any action it deems necessary.
 
 * Requiring that the reported person not use specific language
 * Requiring that the reported person not join in on specific types of discussions

--- a/ENFORCEMENT-POLICY.md
+++ b/ENFORCEMENT-POLICY.md
@@ -1,0 +1,218 @@
+# Typelevel Code of Conduct Committee Enforcement Procedures
+
+This document summarizes the procedures the Typelevel Code of Conduct Committee uses to enforce the Code of Conduct.
+
+
+## Summary of processes
+
+When the committee receives a report of a possible Code of Conduct violation, it will:
+
+1. Acknowledge the receipt of the report.
+2. Evaluate conflicts of interest.
+3. Call a meeting of committee members without a conflict of interest.
+4. Evaluate the reported incident.
+5. Propose a behavior adjustment.
+6. Propose consequences for the reported behavior.
+7. Vote on behavior adjustment and consequences for the reported person.
+8. Contact online community administrators/moderators to approve the behavior adjustment and consequences.
+9. Follow up with the reported person.
+10. Decide further responses.
+11. Follow up with the reporter.
+
+
+### Affiliate project processes
+
+Typelevel affiliate projects are also covered by the Typelevel Code of Conduct. An affiliate project may choose to nominate dedicated moderators, who will work with the Typelevel Code of Conduct Committee to handle reports. 
+
+If a moderator of an affiliate project receives a report, they should:
+1. Acknowledge the receipt of the report.
+2. Contact the Code of Conduct Committee, stating "I have a report that involves [REPORTED PERSON]" so that Code of Conduct Committee members can evaluate conflicts of interest.
+3. The reporting process will proceed as usual, with the affiliate moderator/s included as acting members of the Code of Conduct Committee.
+
+If the Code of Conduct Committee receives a report regarding an affiliate project, the affiliate moderator/s will be included in the conflict of interest evaluation. If no conflict exists, the affiliate moderator/s will be included in the reporting process as acting Code of Conduct committee members.
+
+
+## Acknowledge the report
+
+Reporters should receive an acknowledgment of the receipt of their report within 24 hours, via their preferred communication channel.
+
+
+## Conflict of interest policy
+
+Examples of conflicts of interest include but are not limited to the following circumstances, where the reporter or reported person is
+
+* your manager.
+* a romantic partner, [metamour](https://solopoly.net/2012/09/29/whats-a-metamour-on-my-terms/), or close friend. It's fine to participate if they are an acquaintance.
+* your family member.
+* your direct client.
+* someone you work closely with. This could be someone on your team or someone who works on the same project as you.
+* a maintainer who regularly reviews your contributions.
+
+Committee members do not need to state why they have a conflict of interest, only that one exists. Other committee members should not ask why the person has a conflict of interest.
+
+Anyone who has a conflict of interest will remove themselves from the discussion of the incident, and recuse themselves from voting on a response to the report.
+
+
+## Evaluating a report
+
+### Jurisdiction
+
+* _Is this a Code of Conduct violation?_ Is this behavior on our list of inappropriate behavior? Is it borderline inappropriate behavior? Does it violate our community norms?
+* _Did this occur in a space that is within our Code of Conduct's scope?_ If the incident occurred outside the community, but a community member's mental health or physical safety may be negatively impacted if no action is taken, the incident may be in scope. Private conversations in community spaces are also in scope.
+
+
+### Impact
+
+* _Did this incident occur in a private or public space?_ The more community members are able to access or were present in such a space where the incident occurred, the larger the negative impact.
+* _Does this behavior negatively impact a marginalized group in our community?_ Is the reporter a person from a marginalized group in our community? How is the reporter being negatively impacted by the reported person's behavior? Are members of the marginalized group likely to disengage with the community if no action was taken on this report?
+* _Does this incident involve a community leader?_ Community members often look up to community leaders to set the standard of acceptable behavior, and so reports involving a community leader can have significant negative impact.
+
+
+### Risk
+
+* _Does this incident include sexual harassment?_
+* _Does this pose a safety risk?_ Does the behavior put a person's physical safety at risk? Will this incident severely negatively impact someone's mental health?
+* _Is there a risk of this behavior being repeated?_ Does the reported person understand why their behavior was inappropriate? Is there an established pattern of behavior from past reports?
+
+Reports which involve higher risk or higher impact may face more severe consequences than reports which involve lower risk or lower impact.
+
+
+## Propose a behavior adjustment
+
+The committee will propose a concrete behavior adjustment that ensures the inappropriate behavior is not repeated. The committee will also discuss what actions may need to be taken if the reported person does not agree to the proposed behavioral adjustment.
+
+What follows are examples of possible behavioral adjustments for incidents that occur in online spaces under the scope of this Code of Conduct. This behavioral adjustment list is not inclusive, and the Typelevel Code of Conduct Committee reserves the right to take any action it deems necessary.
+
+* Requiring that the reported person not use specific language
+* Requiring that the reported person not join in on specific types of discussions
+* Requiring that the reported person not send private messages to a community member
+* Requiring that the reported person not join, or leave, specific communication channels
+* Removing the reported person from administrator or moderator rights to community infrastructure
+* Removing a volunteer from their duties and responsibilities
+* Removing a person from leadership of relevant organizations
+* Removing a person from membership of relevant organizations
+
+
+## Propose consequences
+
+What follows are examples of possible consequences to an incident report. This consequences list is not exhaustive, and the Typelevel Code of Conduct Committee reserves the right to take any action it deems necessary.
+
+Possible private responses to an incident include:
+
+* Nothing, if the behavior was determined to not be a Code of Conduct violation
+* A verbal or emailed warning
+* A final warning
+* Temporarily removing the reported person from the online community
+* Permanently removing the reported person from the online community
+
+If deemed necessary for community safety, a public account of an incident, and consequences, may be published.
+
+## Committee vote
+
+Some committee members may have a conflict of interest and may be excluded from discussions of a particular incident report. Excluding those members, decisions on the behavioral adjustment and consequences will be determined by a two-thirds majority vote of the Typelevel Code of Conduct Committee.
+
+
+## Administrators/moderators Communication
+
+Once the committee has approved the proposed behavioral adjustment and consequences, they will communicate the recommended response to the Typelevel Steering Committee, and any specific administrators/moderators of the related community space (ex. Discord moderators, GitHub organization administrators, etc.) The committee should not state who reported this incident. They should attempt to anonymize any identifying information from the report.
+
+Administrators/moderators are required to respond back with whether they accept the recommended response to the report. If they disagree with the recommended response, they should provide a detailed response or additional context as to why they disagree. Administrators/moderators are encouraged to respond within a week.
+
+In cases where the administrators/moderators disagree on the suggested resolution for a report, the Typelevel Code of Conduct Committee shall notify the Typelevel Steering Committee.
+
+
+## Initial follow-up with the reported person
+
+The Typelevel Code of Conduct Committee will draft a response to the reported person.
+The response should contain:
+
+* A description of the person's behavior in neutral language
+* The negative impact of that behavior
+* A concrete proposed behavior adjustment
+* Any consequences of their behavior
+
+The committee should not state who reported this incident. They should attempt to anonymize any identifying information from the report. The reported person should be discouraged from contacting the reporter to discuss the report. 
+
+
+## Further responses
+
+The reported person may respond with additional context. Depending on the response, the Typelevel Code of Conduct Committee may re-evaluate the proposed behavior adjustment and consequences. If the reported person wishes to apologize to the reporter, the committee can accept the apology on behalf of the reporter.
+
+
+## Follow-up with the reporter
+
+A person who makes a report should receive a follow up, via their preferred communication channel, stating what action was taken in response to the report. If the committee decided no response was needed, they should explain why it was not a Code of Conduct violation. Reports that are not made in good faith (such as "reverse sexism" or "reverse racism") may receive no response.
+
+The follow up should be sent no later than one week after the receipt of the report. If deliberation or follow up with the reported person takes longer than one week, the committee should send a status update to the reporter.
+
+
+## Documentation and Privacy Policies
+
+### Committee shared email address
+
+It is convenient for all members of the Code of Conduct committee to be reached by a single email address. The committee should use an email alias which forwards email to individual members.
+
+Using a mailing list is not recommended. This is because mailing lists typically archive all emails. This means new committee members gain access to all past archives. They can deliberately or accidentally see past reports where they have a conflict of interest. In order to prevent potential conflicts of interest, it is recommended to not have a mailing list archive.
+
+
+### Committee online discussion
+
+The Code of Conduct Committee will use an encrypted service for online discussion and deliberation. The Committee may choose something that works for the majority of current members; two possible recommendations are Matrix or Signal. 
+
+When a report comes in and a discussion needs to happen in an online space, care needs to be taken to avoid conflicts of interest. In the committee chat channel, state 'We have a report that involves [REPORTED PERSON]'. Do not say who was the reporter or who were witnesses if the report was sent to an individual committee member. Ask which committee members do not have a conflict of interest. Add those committee members to a group discussion, separate from the committee channel. If a committee member does not respond, do not add them to the new group discussion. If a committee member finds they have a conflict of interest because of who reported the incident or who witnessed it, they should recuse themselves from the discussion.
+
+### Shared Documentation
+
+The Code of Conduct committee should keep two types of shared documents:
+
+* A spreadsheet with the status of open and closed cases
+* A separate, encrypted, document for each report
+
+
+#### Status Spreadsheet
+
+The spreadsheet for Typelevel Code of Conduct reports is linked in the private steering repository README.
+Keep resolutions and notes vague enough that enforcement team members with a conflict of interest don't know the details of the incident. Use gender neutral language when describing the reported person in the spreadsheet.
+
+
+#### Report Documentation
+
+A template report document is linked in the status spreadsheet, as well as the private steering repository README. Report documentation must be encrypted to protect personally identifiable information (PII).
+
+#### Privacy Concerns
+
+There are some common privacy pitfalls to online tools like Google Docs. Make sure to always share the document with committee members who don't have a conflict of interest, rather than turning link sharing on. This prevents people outside of the committee from accessing the documents.
+
+Another common issue is that when a folder is shared with the whole committee, even if a person doesn't have edit or view access to an individual report, they can still see the document's title. This can give information away, and that's why the report template instructs naming the document with a random phrase.
+
+When on-boarding new committee members, they should be provided with a list of names of people who have been reported in a Code of Conduct incident. The new committee member should state whether they have any conflicts of interest with reviewing documentation for those cases. If not, they will be given access to the report documents.
+
+
+## Changes to Code of Conduct
+
+When discussing a change to the Typelevel Code of Conduct or enforcement policies, the Typelevel Code of Conduct Committee will follow this decision-making process:
+
+* Brainstorm options. Code of Conduct committee members should discuss any relevant context and brainstorm a set of possible options. It is important to provide constructive feedback without getting side-tracked from the main question. Brainstorming should be limited to 3-7 days maximum.
+* Vote. Once a working draft is in place for the Code of Conduct and procedures, the Code of Conduct committee shall provide the Typelevel Steering Committee with a PR of the changes. The Steering Committee will vote on the changes, following the usual process and requiring at least ⅔ affirmative vote for the changes to be accepted.
+
+
+### Current list of Code of Conduct Committee members
+
+Jasna Rodulfa-Blemberg, Sam Pillsworth, Andrew Valencik
+
+
+### Advisers
+
+Advisers to the Typelevel Code of Conduct committee have access to the committee mailing list, but are not voting members.
+
+Justin du Coeur, Seth Tisue
+
+
+## Attribution
+
+This enforcement policy is a modified version of the [Python Software Foundation Code of Conduct Enforcement Policy](https://www.python.org/psf/conduct/enforcement/), part of the Python Software Foundation Code of Conduct, licensed under the [Creative Commons Attribution-ShareAlike 3.0 Unported License](https://creativecommons.org/licenses/by-sa/3.0/).
+
+* The [PyCon Code of Conduct](https://us.pycon.org/2018/about/code-of-conduct/) is licensed under a [Creative Commons Attribution 3.0 Unported License](http://creativecommons.org/licenses/by/3.0/).
+* Ada Initiative's guide titled "[Conference anti-harassment/Responding to Reports](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Responding_to_reports)" is licensed under a [Creative Commons Attribution 3.0 Unported License](http://creativecommons.org/licenses/by/3.0/)
+* Audrey Eschright of [Safety First PDX](http://safetyfirstpdx.org/) provided the impact vs risk assessment framework, which is licensed under a [Creative Commons Attribution Share-Alike 3.0 Unported License](http://creativecommons.org/licenses/by-sa/3.0/) by Audrey Eschright of [Safety First PDX](http://safetyfirstpdx.org/)
+* [Code of Conduct template](https://github.com/sagesharp/code-of-conduct-template/) was created by [Otter Tech](https://otter.technology/code-of-conduct-training) and is licensed under a [Creative Commons Attribution 3.0 Unported License](http://creativecommons.org/licenses/by/3.0/)

--- a/ENFORCEMENT-POLICY.md
+++ b/ENFORCEMENT-POLICY.md
@@ -32,6 +32,11 @@ If a moderator of an affiliate project receives a report, they should:
 If the Code of Conduct Committee receives a report regarding an affiliate project, the affiliate moderator/s will be included in the conflict of interest evaluation. If no conflict exists, the affiliate moderator/s will be included in the reporting process as acting Code of Conduct committee members.
 
 
+### Moderator Processes
+
+Typelevel Code of Conduct committee members, affiliate project moderators, and moderators in other spaces covered by the Typelevel Code of Conduct are empowered to enforce the Code of Conduct pro-actively. Code of Conduct violations should still be reported as a follow up, with a note about any action taken in the moment.
+
+
 ## Acknowledge the report
 
 Reporters should receive an acknowledgment of the receipt of their report within 24 hours, via their preferred communication channel.


### PR DESCRIPTION
This PR introduces a new Code of Conduct and Enforcement Policy for Typelevel. These documents are forked from the [Python Software Foundation Code of Conduct](https://www.python.org/psf/conduct/) and [Enforcement Policy](https://www.python.org/psf/conduct/enforcement/).

The scope of this Code of Conduct and Enforcement Policy encompasses both organization **and** affiliate projects (as described in the [Typelevel Charter](https://github.com/typelevel/governance/blob/main/CHARTER.md)). While the Typelevel Charter has always specified that affiliate projects must adhere to the Typelevel organization policies, including the Code of Conduct, this has not been enforced in practice.

Prior to this change the Typelevel Code of Conduct was a fork of the Scala Code of Conduct. We, the Typelevel Steering Committee, are choosing the Python Software Foundation Code of Conduct to fork because it has an accompanying enforcement policy, and there is associated training available. Some Typelevel Steering Committee members engaged in this training through [Otter Technology](https://otter.technology/code-of-conduct-training/) in late 2023. All Code of Conduct Committee members will be encouraged to take this (or equivalent) training going forward. 

We believe our community is already a kind and welcoming place. However, a Code of Conduct must be enforced to maintain community trust and safety. Additionally, an enforcement policy is useful to provide transparency and accountability on how the Code of Conduct Committee will work.


### What happens next?
The Code of Conduct and Enforcement Policy must be voted in by the Typelevel Steering Committee. We will then update our site and begin updating the `CODE_OF_CONDUCT` files in organization project repositories.

### As an affiliate project maintainer, what should I expect?
Once the Code of Conduct is voted in, going forward all affiliate projects will be expected to adopt the Typelevel Code of Conduct. We will open pull requests to update each affiliate project's `CODE_OF_CONDUCT` file. If a project chooses not to adopt the Typelevel Code of Conduct, they can close the PR, and we'll handle removing the project from the affiliate project list. This is totally fine and we support your choices! We believe open source developers are free to choose the projects they contribute to and the communities they support :heart: 

### Can an affiliate project maintainer participate in Code of Conduct enforcement?
Affiliate project's can list additional moderators in their `CODE_OF_CONDUCT` file, that the Typelevel Code of Conduct Committee will work with as described in the Enforcement Policy "Affiliate project processes" section. Additionally, if this work interests you, keep an eye out for future calls for Typelevel Code of Conduct Committee members!